### PR TITLE
Adjust grid size to 5x4 and improve card fitting

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "defaultSize": {
-        "rows": 5,
+        "rows": 4,
         "cols": 5
     },
     "pairs": [

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ body {
 
 .container {
     width: 100%;
-    max-width: min(95vh, 1200px);
+    max-width: min(95vh * 1.25, 1200px);
     margin: 0 auto;
     padding: 20px;
     display: flex;
@@ -63,7 +63,7 @@ body {
     gap: 10px;
     margin: 0 auto;
     width: 100%;
-    aspect-ratio: 1;
+    aspect-ratio: 5/4;
 }
 
 .card {


### PR DESCRIPTION
- Changed default grid size from 5x5 to 5x4
- Adjusted container width to better fit 5x4 grid
- Updated game board aspect ratio to match new grid size